### PR TITLE
Enable chunked parquet output support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raquet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
     "GDAL>=3",
     "mercantile>=1",

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -1,3 +1,4 @@
+import glob
 import itertools
 import os
 import tempfile
@@ -157,6 +158,49 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(table.column_names, ["block", "metadata", "band_1"])
 
         metadata = geotiff2raquet.read_metadata(table)
+        self.assertEqual(metadata["compression"], "gzip")
+        self.assertEqual(metadata["width"], 1536)
+        self.assertEqual(metadata["height"], 1792)
+        self.assertEqual(metadata["num_blocks"], 42)
+        self.assertEqual(metadata["num_pixels"], 2752512)
+        self.assertEqual(metadata["nodata"], 250.0)
+        self.assertEqual(metadata["block_resolution"], 13)
+        self.assertEqual(metadata["pixel_resolution"], 21)
+        self.assertEqual(metadata["minresolution"], 10)
+        self.assertEqual(metadata["maxresolution"], 13)
+
+        stats = metadata["bands"][0]["stats"]
+        self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
+        self.assertEqual(f"{stats['max']:.4g}", "95")
+        self.assertEqual(f"{stats['mean']:.4g}", "75.85")
+        self.assertEqual(f"{stats['min']:.4g}", "11")
+        self.assertEqual(f"{stats['stddev']:.4g}", "16.47")
+        self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
+
+    def test_multipart_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
+        geotiff_filename = os.path.join(
+            PROJDIR, "tests/Annual_NLCD_LndCov_2023_CU_C1V0.tif"
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            raquet_destination = os.path.join(tempdir, "out")
+            geotiff2raquet.main(
+                geotiff_filename,
+                raquet_destination,
+                geotiff2raquet.ZoomStrategy.UPPER,
+                geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
+                max_size=64000,
+            )
+            tables = [
+                pyarrow.parquet.read_table(name)
+                for name in glob.glob(f"{raquet_destination}/*.parquet")
+            ]
+
+        self.assertEqual(sum(len(table) for table in tables), 63)
+        for table in tables:
+            self.assertEqual(table.column_names, ["block", "metadata", "band_1"])
+
+        metadata = geotiff2raquet.read_metadata(tables[-1])
         self.assertEqual(metadata["compression"], "gzip")
         self.assertEqual(metadata["width"], 1536)
         self.assertEqual(metadata["height"], 1792)

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -193,7 +193,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
             )
             tables = [
                 pyarrow.parquet.read_table(name)
-                for name in glob.glob(f"{raquet_destination}/*.parquet")
+                for name in sorted(glob.glob(f"{raquet_destination}/*.parquet"))
             ]
 
         self.assertEqual(sum(len(table) for table in tables), 63)

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -196,6 +196,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 for name in sorted(glob.glob(f"{raquet_destination}/*.parquet"))
             ]
 
+        self.assertGreater(len(tables), 1)
         self.assertEqual(sum(len(table) for table in tables), 63)
         for table in tables:
             self.assertEqual(table.column_names, ["block", "metadata", "band_1"])

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -189,7 +189,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 raquet_destination,
                 geotiff2raquet.ZoomStrategy.UPPER,
                 geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
-                max_size=64000,
+                target_size=64000,
             )
             tables = [
                 pyarrow.parquet.read_table(name)

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -20,6 +20,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 raquet_filename,
                 geotiff2raquet.ZoomStrategy.AUTO,
                 geotiff2raquet.ResamplingAlgorithm.CubicSpline,
+                8,
             )
             table = pyarrow.parquet.read_table(raquet_filename)
 
@@ -103,6 +104,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 raquet_filename,
                 geotiff2raquet.ZoomStrategy.LOWER,
                 geotiff2raquet.ResamplingAlgorithm.CubicSpline,
+                8,
             )
             table = pyarrow.parquet.read_table(raquet_filename)
 
@@ -140,7 +142,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['sum']:.4g}", "3.704e+06")
         self.assertEqual(f"{stats['sum_squares']:.4g}", "4.539e+08")
 
-    def test_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
+    def test_smalltile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
             PROJDIR, "tests/Annual_NLCD_LndCov_2023_CU_C1V0.tif"
         )
@@ -151,6 +153,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 raquet_filename,
                 geotiff2raquet.ZoomStrategy.UPPER,
                 geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
+                8,
             )
             table = pyarrow.parquet.read_table(raquet_filename)
 
@@ -162,7 +165,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["width"], 1536)
         self.assertEqual(metadata["height"], 1792)
         self.assertEqual(metadata["num_blocks"], 42)
-        self.assertEqual(metadata["num_pixels"], 2752512)
+        self.assertEqual(metadata["num_pixels"], 1536 * 1792)
         self.assertEqual(metadata["nodata"], 250.0)
         self.assertEqual(metadata["block_resolution"], 13)
         self.assertEqual(metadata["pixel_resolution"], 21)
@@ -178,6 +181,84 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
         self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
 
+    def test_medtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
+        geotiff_filename = os.path.join(
+            PROJDIR, "tests/Annual_NLCD_LndCov_2023_CU_C1V0.tif"
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            raquet_filename = os.path.join(tempdir, "out.parquet")
+            geotiff2raquet.main(
+                geotiff_filename,
+                raquet_filename,
+                geotiff2raquet.ZoomStrategy.UPPER,
+                geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
+                9,
+            )
+            table = pyarrow.parquet.read_table(raquet_filename)
+
+        self.assertEqual(len(table), 22)
+        self.assertEqual(table.column_names, ["block", "metadata", "band_1"])
+
+        metadata = geotiff2raquet.read_metadata(table)
+        self.assertEqual(metadata["compression"], "gzip")
+        self.assertEqual(metadata["width"], 1536)
+        self.assertEqual(metadata["height"], 2048)
+        self.assertEqual(metadata["num_blocks"], 12)
+        self.assertEqual(metadata["num_pixels"], 1536 * 2048)
+        self.assertEqual(metadata["nodata"], 250.0)
+        self.assertEqual(metadata["block_resolution"], 12)
+        self.assertEqual(metadata["pixel_resolution"], 21)
+        self.assertEqual(metadata["minresolution"], 9)
+        self.assertEqual(metadata["maxresolution"], 12)
+
+        stats = metadata["bands"][0]["stats"]
+        self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
+        self.assertEqual(f"{stats['max']:.4g}", "95")
+        self.assertEqual(f"{stats['mean']:.4g}", "75.85")
+        self.assertEqual(f"{stats['min']:.4g}", "11")
+        self.assertEqual(f"{stats['stddev']:.4g}", "17.25") # "16.47")
+        self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
+
+    def test_bigtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
+        geotiff_filename = os.path.join(
+            PROJDIR, "tests/Annual_NLCD_LndCov_2023_CU_C1V0.tif"
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            raquet_filename = os.path.join(tempdir, "out.parquet")
+            geotiff2raquet.main(
+                geotiff_filename,
+                raquet_filename,
+                geotiff2raquet.ZoomStrategy.UPPER,
+                geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
+                10,
+            )
+            table = pyarrow.parquet.read_table(raquet_filename)
+
+        self.assertEqual(len(table), 11)
+        self.assertEqual(table.column_names, ["block", "metadata", "band_1"])
+
+        metadata = geotiff2raquet.read_metadata(table)
+        self.assertEqual(metadata["compression"], "gzip")
+        self.assertEqual(metadata["width"], 2048)
+        self.assertEqual(metadata["height"], 3072)
+        self.assertEqual(metadata["num_blocks"], 6)
+        self.assertEqual(metadata["num_pixels"], 2048 * 3072)
+        self.assertEqual(metadata["nodata"], 250.0)
+        self.assertEqual(metadata["block_resolution"], 11)
+        self.assertEqual(metadata["pixel_resolution"], 21)
+        self.assertEqual(metadata["minresolution"], 8)
+        self.assertEqual(metadata["maxresolution"], 11)
+
+        stats = metadata["bands"][0]["stats"]
+        self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
+        self.assertEqual(f"{stats['max']:.4g}", "95")
+        self.assertEqual(f"{stats['mean']:.4g}", "75.85")
+        self.assertEqual(f"{stats['min']:.4g}", "11")
+        self.assertEqual(f"{stats['stddev']:.4g}", "18.28") # "16.47")
+        self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
+
     def test_multipart_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
             PROJDIR, "tests/Annual_NLCD_LndCov_2023_CU_C1V0.tif"
@@ -190,6 +271,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 geotiff2raquet.ZoomStrategy.UPPER,
                 geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
                 target_size=64000,
+                block_zoom=8,
             )
             tables = [
                 pyarrow.parquet.read_table(name)
@@ -231,6 +313,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 raquet_filename,
                 geotiff2raquet.ZoomStrategy.UPPER,
                 geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
+                8,
             )
             table = pyarrow.parquet.read_table(raquet_filename)
 
@@ -267,6 +350,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
                 raquet_filename,
                 geotiff2raquet.ZoomStrategy.AUTO,
                 geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
+                8,
             )
             table = pyarrow.parquet.read_table(raquet_filename)
 

--- a/raquet/__init__.py
+++ b/raquet/__init__.py
@@ -10,9 +10,10 @@ def geotiff2raquet_main():
         logging.basicConfig(level=logging.INFO)
     geotiff2raquet.main(
         args.geotiff_filename,
-        args.raquet_filename,
+        args.raquet_destination,
         geotiff2raquet.ZoomStrategy(args.zoom_strategy),
         geotiff2raquet.ResamplingAlgorithm(args.resampling_algorithm),
+        args.max_size,
     )
 
 

--- a/raquet/__init__.py
+++ b/raquet/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 from . import geotiff2raquet
 from . import raquet2geotiff
@@ -8,11 +9,16 @@ def geotiff2raquet_main():
     args = geotiff2raquet.parser.parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.INFO)
+
+    # Zoom offset from tiles to pixels, e.g. 8 = 256px tiles
+    block_zoom=int(math.log(args.block_size) / math.log(2))
+
     geotiff2raquet.main(
         args.geotiff_filename,
         args.raquet_destination,
         geotiff2raquet.ZoomStrategy(args.zoom_strategy),
         geotiff2raquet.ResamplingAlgorithm(args.resampling_algorithm),
+        block_zoom,
         args.target_size,
     )
 

--- a/raquet/__init__.py
+++ b/raquet/__init__.py
@@ -13,7 +13,7 @@ def geotiff2raquet_main():
         args.raquet_destination,
         geotiff2raquet.ZoomStrategy(args.zoom_strategy),
         geotiff2raquet.ResamplingAlgorithm(args.resampling_algorithm),
-        args.max_size,
+        args.target_size,
     )
 
 

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -611,6 +611,9 @@ def flush_rows_to_file(
     writer: pyarrow.parquet.ParquetWriter, schema: pyarrow.lib.Schema, rows: list[dict]
 ):
     """Write a list of rows then destructively clear it in-place"""
+    if not rows:  # Skip writing if rows is empty
+        return
+
     rows_dict = {key: [row[key] for row in rows] for key in schema.names}
     table = pyarrow.Table.from_pydict(rows_dict, schema=schema)
     writer.write_table(table, row_group_size=len(rows))

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -642,8 +642,9 @@ def main(
     if target_size is None:
         raquet_destinations = itertools.repeat((raquet_destination, math.inf))
     else:
-        if not os.path.isdir(raquet_destination):
-            os.mkdir(raquet_destination)
+        if os.path.exists(raquet_destination):
+            raise ValueError(f"{raquet_destination} already exists")
+        os.mkdir(raquet_destination)
         # Prepare a generator of sequential file names
         raquet_destinations = (
             (os.path.join(raquet_destination, f"part{i:03d}.parquet"), target_size)


### PR DESCRIPTION
* Add optional `--target-size` argument with byte count for multi-part RaQuet files to be written to a destination directory, old single-file behavior retained when this is omitted
* Add optional `--block-size` argument with pixel dimensions of tile blocks, old default of 256px retained by default

Closes #18