### PR TITLE
Add support for Numpy if available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,15 @@
 [project]
 name = "raquet"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
     "GDAL>=3",
     "mercantile>=1",
     "pyarrow>=19",
     "quadbin>=0.2.2",
 ]
+
+[project.optional-dependencies]
+numpy = ["numpy>=2"]
 
 [tool.setuptools]
 packages = ["raquet"]

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -32,7 +32,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertAlmostEqual(stats.stddev, 28.722813233)
 
     def test_read_statistics_numpy(self):
-        if geotiff2raquet.has_numpy:
+        if geotiff2raquet.HAS_NUMPY:
             with unittest.mock.patch("numpy.ma") as mock_numpy_ma:
                 input_arr = unittest.mock.Mock()
                 stats = geotiff2raquet.read_statistics_numpy(input_arr, 0)

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -31,19 +31,20 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(stats.blocks, 1)
         self.assertAlmostEqual(stats.stddev, 28.722813233)
 
-    @unittest.mock.patch("numpy.ma")
-    def test_read_statistics_numpy(self, mock_numpy_ma):
-        input_arr = unittest.mock.Mock()
-        stats = geotiff2raquet.read_statistics_numpy(input_arr, 0)
-        mock_numpy_ma.masked_array.assert_any_call(input_arr, input_arr == 0)
-        masked_arr = mock_numpy_ma.masked_array.return_value
-        masked_arr.count.assert_called_once()
-        masked_arr.min.assert_called_once()
-        masked_arr.max.assert_called_once()
-        masked_arr.mean.assert_called_once()
-        masked_arr.sum.assert_called_once()
-        self.assertEqual(stats.blocks, 1)
-        masked_arr.std.assert_called_once()
+    def test_read_statistics_numpy(self):
+        if geotiff2raquet.has_numpy:
+            with unittest.mock.patch("numpy.ma") as mock_numpy_ma:
+                input_arr = unittest.mock.Mock()
+                stats = geotiff2raquet.read_statistics_numpy(input_arr, 0)
+                mock_numpy_ma.masked_array.assert_any_call(input_arr, input_arr == 0)
+                masked_arr = mock_numpy_ma.masked_array.return_value
+            masked_arr.count.assert_called_once()
+            masked_arr.min.assert_called_once()
+            masked_arr.max.assert_called_once()
+            masked_arr.mean.assert_called_once()
+            masked_arr.sum.assert_called_once()
+            self.assertEqual(stats.blocks, 1)
+            masked_arr.std.assert_called_once()
 
     def test_europe_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "examples/europe.tif")

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -19,6 +19,17 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(geotiff2raquet.find_minzoom(rg, 7), 0)
         self.assertEqual(geotiff2raquet.find_minzoom(rg, 8), 0)
 
+    def test_read_statistics(self):
+        stats = geotiff2raquet.read_statistics(list(range(100)), 0)
+        self.assertEqual(stats.count, 99)
+        self.assertEqual(stats.min, 1)
+        self.assertEqual(stats.max, 99)
+        self.assertEqual(stats.mean, 50)
+        self.assertAlmostEqual(stats.stddev, 28.722813233)
+        self.assertEqual(stats.sum, 4950)
+        self.assertEqual(stats.sum_squares, 328350)
+        self.assertEqual(stats.blocks, 1)
+
     def test_europe_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "examples/europe.tif")
         with tempfile.TemporaryDirectory() as tempdir:

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -20,8 +20,8 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(geotiff2raquet.find_minzoom(rg, 7), 0)
         self.assertEqual(geotiff2raquet.find_minzoom(rg, 8), 0)
 
-    def test_read_statistics(self):
-        stats = geotiff2raquet.read_statistics(list(range(100)), 0)
+    def test_read_statistics_python(self):
+        stats = geotiff2raquet.read_statistics_python(list(range(100)), 0)
         self.assertEqual(stats.count, 99)
         self.assertEqual(stats.min, 1)
         self.assertEqual(stats.max, 99)
@@ -37,13 +37,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         stats = geotiff2raquet.read_statistics_numpy(input_arr, 0)
         mock_numpy_ma.masked_array.assert_any_call(input_arr, input_arr == 0)
         masked_arr = mock_numpy_ma.masked_array.return_value
-        self.assertIs(stats.count, masked_arr.count.return_value)
-        self.assertIs(stats.min, masked_arr.min.return_value)
-        self.assertIs(stats.max, masked_arr.max.return_value)
-        self.assertIs(stats.mean, masked_arr.mean.return_value)
-        self.assertIs(stats.sum, masked_arr.sum.return_value)
+        masked_arr.count.assert_called_once()
+        masked_arr.min.assert_called_once()
+        masked_arr.max.assert_called_once()
+        masked_arr.mean.assert_called_once()
+        masked_arr.sum.assert_called_once()
         self.assertEqual(stats.blocks, 1)
-        self.assertIs(stats.stddev, masked_arr.std.return_value)
+        masked_arr.std.assert_called_once()
 
     def test_europe_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "examples/europe.tif")

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -25,10 +25,24 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(stats.min, 1)
         self.assertEqual(stats.max, 99)
         self.assertEqual(stats.mean, 50)
-        self.assertAlmostEqual(stats.stddev, 28.722813233)
         self.assertEqual(stats.sum, 4950)
         self.assertEqual(stats.sum_squares, 328350)
         self.assertEqual(stats.blocks, 1)
+        self.assertAlmostEqual(stats.stddev, 28.722813233)
+
+    def test_read_statistics_numpy(self):
+        import numpy
+
+        arr = numpy.arange(100).reshape(10, 10)
+        stats = geotiff2raquet.read_statistics_numpy(arr, 0)
+        self.assertEqual(stats.count, 99)
+        self.assertEqual(stats.min, 1)
+        self.assertEqual(stats.max, 99)
+        self.assertEqual(stats.mean, 50)
+        self.assertEqual(stats.sum, 4950)
+        self.assertEqual(stats.sum_squares, 328350)
+        self.assertEqual(stats.blocks, 1)
+        self.assertAlmostEqual(stats.stddev, 28.577380332)
 
     def test_europe_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "examples/europe.tif")

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -242,7 +242,7 @@ def read_statistics_numpy(values: "numpy.array", nodata: int | float | None):
         mean=float(masked_values.mean()),
         stddev=float(masked_values.std()),
         sum=ptype(masked_values.sum()),
-        sum_squares=float((masked_values**2).sum()),
+        sum_squares=float((masked_values.astype(ptype) ** 2).sum()),
     )
 
 

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -230,10 +230,10 @@ def read_statistics_numpy(values: "numpy.array", nodata: int | float | None):
     if value_count == 0:
         return NoDataStats()
 
-    if masked_values.dtype in (numpy.uint8,):
-        ptype = int
-    else:
+    if masked_values.dtype in (numpy.float16, numpy.float32, numpy.float64):
         ptype = float
+    else:
+        ptype = int
 
     return RasterStats(
         count=value_count,

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -39,6 +39,7 @@ try:
     import numpy
     import numpy.ma
 except ImportError:
+    logging.info("Optional Numpy package is unavailable, stats calculation may be slow")
     HAS_NUMPY = False
 else:
     HAS_NUMPY = True

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -39,9 +39,9 @@ try:
     import numpy
     import numpy.ma
 except ImportError:
-    has_numpy = False
+    HAS_NUMPY = False
 else:
-    has_numpy = True
+    HAS_NUMPY = True
 
 # Pixel dimensions of ideal minimum size
 TARGET_MIN_SIZE = 128
@@ -346,7 +346,7 @@ def read_raster_data_stats(
         data = band.ReadRaster(0, 0, band.XSize, band.YSize)
         if gdaltype_bandtypes is not None and include_stats:
             band_type = gdaltype_bandtypes[band.DataType]
-            if has_numpy:
+            if HAS_NUMPY:
                 pixel_arr = numpy.frombuffer(data, dtype=getattr(numpy, band_type.name))
                 stats = read_statistics_numpy(pixel_arr, band.GetNoDataValue())
             else:


### PR DESCRIPTION
Raster stats are faster to compute with Numpy but we don’t want to require its installation. Use optionally if available.

Related to performance improvements wanted in https://github.com/CartoDB/raquet/issues/14 but still calculates full stats.