### PR TITLE
Support approximate stats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raquet"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
     "GDAL>=3",
     "mercantile>=1",

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -27,7 +27,6 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(stats.mean, 50)
         self.assertEqual(stats.sum, 4950)
         self.assertEqual(stats.sum_squares, 328350)
-        self.assertEqual(stats.blocks, 1)
         self.assertAlmostEqual(stats.stddev, 28.722813233)
 
     def test_read_statistics_numpy(self):
@@ -42,7 +41,6 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(stats.mean, 50)
         self.assertEqual(stats.sum, 4950)
         self.assertEqual(stats.sum_squares, 328350)
-        self.assertEqual(stats.blocks, 1)
         self.assertAlmostEqual(stats.stddev, 28.577380332)
 
     def test_europe_tif(self):

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -173,6 +173,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['stddev']:.3g}", "54.6")
         self.assertEqual(f"{stats['sum']:.3g}", "3.71e+06")
         self.assertEqual(f"{stats['sum_squares']:.3g}", "4.5e+08")
+        self.assertTrue(stats["approximated_stats"])
 
     def test_smalltile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -212,6 +213,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['stddev']:.3g}", "18.3")
         self.assertEqual(f"{stats['sum']:.3g}", "9.22e+07")
         self.assertEqual(f"{stats['sum_squares']:.3g}", "7.41e+09")
+        self.assertTrue(stats["approximated_stats"])
 
     def test_medtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -251,6 +253,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['stddev']:.2g}", "18")
         self.assertEqual(f"{stats['sum']:.2g}", "9.2e+07")
         self.assertEqual(f"{stats['sum_squares']:.2g}", "7.4e+09")
+        self.assertTrue(stats["approximated_stats"])
 
     def test_bigtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -290,6 +293,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['stddev']:.3g}", "18.5")
         self.assertEqual(f"{stats['sum']:.3g}", "9.24e+07")
         self.assertEqual(f"{stats['sum_squares']:.3g}", "7.42e+09")
+        self.assertTrue(stats["approximated_stats"])
 
     def test_multipart_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -335,6 +339,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['stddev']:.3g}", "18.3")
         self.assertEqual(f"{stats['sum']:.3g}", "9.22e+07")
         self.assertEqual(f"{stats['sum_squares']:.3g}", "7.41e+09")
+        self.assertTrue(stats["approximated_stats"])
 
     def test_geotiff_discreteloss_2023_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/geotiff-discreteloss_2023.tif")
@@ -372,6 +377,7 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['stddev']:.3g}", "0")
         self.assertEqual(f"{stats['sum']:.3g}", "2.7e+04")
         self.assertEqual(f"{stats['sum_squares']:.3g}", "2.7e+04")
+        self.assertTrue(stats["approximated_stats"])
 
     def test_colored_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/colored.tif")

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -246,13 +246,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 12)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.3g}", "1.22e+06")
-        self.assertEqual(f"{stats['max']:.3g}", "95")
-        self.assertEqual(f"{stats['mean']:.3g}", "75.9")
-        self.assertEqual(f"{stats['min']:.3g}", "11")
-        self.assertEqual(f"{stats['stddev']:.3g}", "18.4")
-        self.assertEqual(f"{stats['sum']:.3g}", "9.23e+07")
-        self.assertEqual(f"{stats['sum_squares']:.3g}", "7.42e+09")
+        self.assertEqual(f"{stats['count']:.2g}", "1.2e+06")
+        self.assertEqual(f"{stats['max']:.2g}", "95")
+        self.assertEqual(f"{stats['mean']:.2g}", "76")
+        self.assertEqual(f"{stats['min']:.2g}", "11")
+        self.assertEqual(f"{stats['stddev']:.2g}", "18")
+        self.assertEqual(f"{stats['sum']:.2g}", "9.2e+07")
+        self.assertEqual(f"{stats['sum_squares']:.2g}", "7.4e+09")
 
     def test_bigtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -94,40 +94,40 @@ class TestGeotiff2Raquet(unittest.TestCase):
         )
 
         stats0 = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats0['count']:.4g}", "1.049e+06")
-        self.assertEqual(f"{stats0['max']:.4g}", "255")
-        self.assertEqual(f"{stats0['mean']:.4g}", "104.8")
-        self.assertEqual(f"{stats0['min']:.4g}", "0")
-        self.assertEqual(f"{stats0['stddev']:.4g}", "78.44")
-        self.assertEqual(f"{stats0['sum']:.4g}", "1.099e+08")
-        self.assertEqual(f"{stats0['sum_squares']:.4g}", "1.797e+10")
+        self.assertEqual(f"{stats0['count']:.3g}", "1.05e+06")
+        self.assertEqual(f"{stats0['max']:.3g}", "255")
+        self.assertEqual(f"{stats0['mean']:.3g}", "105")
+        self.assertEqual(f"{stats0['min']:.3g}", "0")
+        self.assertEqual(f"{stats0['stddev']:.3g}", "78.4")
+        self.assertEqual(f"{stats0['sum']:.3g}", "1.1e+08")
+        self.assertEqual(f"{stats0['sum_squares']:.3g}", "1.8e+10")
 
         stats1 = metadata["bands"][1]["stats"]
-        self.assertEqual(f"{stats1['count']:.4g}", "1.049e+06")
-        self.assertEqual(f"{stats1['max']:.4g}", "255")
-        self.assertEqual(f"{stats1['mean']:.4g}", "91.28")
-        self.assertEqual(f"{stats1['min']:.4g}", "0")
-        self.assertEqual(f"{stats1['stddev']:.4g}", "84.34")
-        self.assertEqual(f"{stats1['sum']:.4g}", "9.571e+07")
-        self.assertEqual(f"{stats1['sum_squares']:.4g}", "1.619e+10")
+        self.assertEqual(f"{stats1['count']:.3g}", "1.05e+06")
+        self.assertEqual(f"{stats1['max']:.3g}", "255")
+        self.assertEqual(f"{stats1['mean']:.3g}", "91.3")
+        self.assertEqual(f"{stats1['min']:.3g}", "0")
+        self.assertEqual(f"{stats1['stddev']:.3g}", "84.3")
+        self.assertEqual(f"{stats1['sum']:.3g}", "9.57e+07")
+        self.assertEqual(f"{stats1['sum_squares']:.3g}", "1.62e+10")
 
         stats2 = metadata["bands"][2]["stats"]
-        self.assertEqual(f"{stats2['count']:.4g}", "1.049e+06")
-        self.assertEqual(f"{stats2['max']:.4g}", "255")
-        self.assertEqual(f"{stats2['mean']:.4g}", "124")
-        self.assertEqual(f"{stats2['min']:.4g}", "0")
-        self.assertEqual(f"{stats2['stddev']:.4g}", "81.36")
-        self.assertEqual(f"{stats2['sum']:.4g}", "1.301e+08")
-        self.assertEqual(f"{stats2['sum_squares']:.4g}", "2.307e+10")
+        self.assertEqual(f"{stats2['count']:.3g}", "1.05e+06")
+        self.assertEqual(f"{stats2['max']:.3g}", "255")
+        self.assertEqual(f"{stats2['mean']:.3g}", "124")
+        self.assertEqual(f"{stats2['min']:.3g}", "0")
+        self.assertEqual(f"{stats2['stddev']:.3g}", "81.4")
+        self.assertEqual(f"{stats2['sum']:.3g}", "1.3e+08")
+        self.assertEqual(f"{stats2['sum_squares']:.3g}", "2.31e+10")
 
         stats3 = metadata["bands"][3]["stats"]
-        self.assertEqual(f"{stats3['count']:.4g}", "1.049e+06")
-        self.assertEqual(f"{stats3['max']:.4g}", "255")
-        self.assertEqual(f"{stats3['mean']:.4g}", "190")
-        self.assertEqual(f"{stats3['min']:.4g}", "0")
-        self.assertEqual(f"{stats3['stddev']:.4g}", "110.3")
-        self.assertEqual(f"{stats3['sum']:.4g}", "1.992e+08")
-        self.assertEqual(f"{stats3['sum_squares']:.4g}", "5.059e+10")
+        self.assertEqual(f"{stats3['count']:.3g}", "1.05e+06")
+        self.assertEqual(f"{stats3['max']:.3g}", "255")
+        self.assertEqual(f"{stats3['mean']:.3g}", "190")
+        self.assertEqual(f"{stats3['min']:.3g}", "0")
+        self.assertEqual(f"{stats3['stddev']:.3g}", "110")
+        self.assertEqual(f"{stats3['sum']:.3g}", "1.99e+08")
+        self.assertEqual(f"{stats3['sum_squares']:.3g}", "5.06e+10")
 
     def test_n37_w123_1arc_v2_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/n37_w123_1arc_v2.tif")
@@ -168,13 +168,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         )
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "9.755e+04")
-        self.assertEqual(f"{stats['max']:.4g}", "358")
-        self.assertEqual(f"{stats['mean']:.4g}", "38.07")
-        self.assertEqual(f"{stats['min']:.4g}", "-4")
-        self.assertEqual(f"{stats['stddev']:.4g}", "54.59")
-        self.assertEqual(f"{stats['sum']:.4g}", "3.714e+06")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "4.499e+08")
+        self.assertEqual(f"{stats['count']:.3g}", "9.76e+04")
+        self.assertEqual(f"{stats['max']:.3g}", "358")
+        self.assertEqual(f"{stats['mean']:.3g}", "38.1")
+        self.assertEqual(f"{stats['min']:.3g}", "-4")
+        self.assertEqual(f"{stats['stddev']:.3g}", "54.6")
+        self.assertEqual(f"{stats['sum']:.3g}", "3.71e+06")
+        self.assertEqual(f"{stats['sum_squares']:.3g}", "4.5e+08")
 
     def test_smalltile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -207,13 +207,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 13)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
-        self.assertEqual(f"{stats['max']:.4g}", "95")
-        self.assertEqual(f"{stats['mean']:.4g}", "75.82")
-        self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "18.3")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.218e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.409e+09")
+        self.assertEqual(f"{stats['count']:.3g}", "1.22e+06")
+        self.assertEqual(f"{stats['max']:.3g}", "95")
+        self.assertEqual(f"{stats['mean']:.3g}", "75.8")
+        self.assertEqual(f"{stats['min']:.3g}", "11")
+        self.assertEqual(f"{stats['stddev']:.3g}", "18.3")
+        self.assertEqual(f"{stats['sum']:.3g}", "9.22e+07")
+        self.assertEqual(f"{stats['sum_squares']:.3g}", "7.41e+09")
 
     def test_medtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -246,13 +246,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 12)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
-        self.assertEqual(f"{stats['max']:.4g}", "95")
-        self.assertEqual(f"{stats['mean']:.4g}", "75.85")
-        self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "18.43")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.226e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.416e+09")
+        self.assertEqual(f"{stats['count']:.3g}", "1.22e+06")
+        self.assertEqual(f"{stats['max']:.3g}", "95")
+        self.assertEqual(f"{stats['mean']:.3g}", "75.9")
+        self.assertEqual(f"{stats['min']:.3g}", "11")
+        self.assertEqual(f"{stats['stddev']:.3g}", "18.4")
+        self.assertEqual(f"{stats['sum']:.3g}", "9.23e+07")
+        self.assertEqual(f"{stats['sum_squares']:.3g}", "7.42e+09")
 
     def test_bigtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -285,13 +285,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 11)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "1.218e+06")
-        self.assertEqual(f"{stats['max']:.4g}", "95")
-        self.assertEqual(f"{stats['mean']:.4g}", "75.84")
-        self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "18.55")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.236e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.424e+09")
+        self.assertEqual(f"{stats['count']:.3g}", "1.22e+06")
+        self.assertEqual(f"{stats['max']:.3g}", "95")
+        self.assertEqual(f"{stats['mean']:.3g}", "75.8")
+        self.assertEqual(f"{stats['min']:.3g}", "11")
+        self.assertEqual(f"{stats['stddev']:.3g}", "18.5")
+        self.assertEqual(f"{stats['sum']:.3g}", "9.24e+07")
+        self.assertEqual(f"{stats['sum_squares']:.3g}", "7.42e+09")
 
     def test_multipart_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -330,13 +330,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 13)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
-        self.assertEqual(f"{stats['max']:.4g}", "95")
-        self.assertEqual(f"{stats['mean']:.4g}", "75.82")
-        self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "18.3")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.218e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.409e+09")
+        self.assertEqual(f"{stats['count']:.3g}", "1.22e+06")
+        self.assertEqual(f"{stats['max']:.3g}", "95")
+        self.assertEqual(f"{stats['mean']:.3g}", "75.8")
+        self.assertEqual(f"{stats['min']:.3g}", "11")
+        self.assertEqual(f"{stats['stddev']:.3g}", "18.3")
+        self.assertEqual(f"{stats['sum']:.3g}", "9.22e+07")
+        self.assertEqual(f"{stats['sum_squares']:.3g}", "7.41e+09")
 
     def test_geotiff_discreteloss_2023_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/geotiff-discreteloss_2023.tif")
@@ -367,13 +367,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 13)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "2.698e+04")
-        self.assertEqual(f"{stats['max']:.4g}", "1")
-        self.assertEqual(f"{stats['mean']:.4g}", "1")
-        self.assertEqual(f"{stats['min']:.4g}", "1")
-        self.assertEqual(f"{stats['stddev']:.4g}", "0")
-        self.assertEqual(f"{stats['sum']:.4g}", "2.698e+04")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "2.698e+04")
+        self.assertEqual(f"{stats['count']:.3g}", "2.7e+04")
+        self.assertEqual(f"{stats['max']:.3g}", "1")
+        self.assertEqual(f"{stats['mean']:.3g}", "1")
+        self.assertEqual(f"{stats['min']:.3g}", "1")
+        self.assertEqual(f"{stats['stddev']:.3g}", "0")
+        self.assertEqual(f"{stats['sum']:.3g}", "2.7e+04")
+        self.assertEqual(f"{stats['sum_squares']:.3g}", "2.7e+04")
 
     def test_colored_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/colored.tif")

--- a/raquet-tests/test-geotiff2raquet.py
+++ b/raquet-tests/test-geotiff2raquet.py
@@ -96,38 +96,38 @@ class TestGeotiff2Raquet(unittest.TestCase):
         stats0 = metadata["bands"][0]["stats"]
         self.assertEqual(f"{stats0['count']:.4g}", "1.049e+06")
         self.assertEqual(f"{stats0['max']:.4g}", "255")
-        self.assertEqual(f"{stats0['mean']:.4g}", "104.7")
+        self.assertEqual(f"{stats0['mean']:.4g}", "104.8")
         self.assertEqual(f"{stats0['min']:.4g}", "0")
-        self.assertEqual(f"{stats0['stddev']:.4g}", "63.24")
-        self.assertEqual(f"{stats0['sum']:.4g}", "1.098e+08")
-        self.assertEqual(f"{stats0['sum_squares']:.4g}", "1.827e+10")
+        self.assertEqual(f"{stats0['stddev']:.4g}", "78.44")
+        self.assertEqual(f"{stats0['sum']:.4g}", "1.099e+08")
+        self.assertEqual(f"{stats0['sum_squares']:.4g}", "1.797e+10")
 
         stats1 = metadata["bands"][1]["stats"]
         self.assertEqual(f"{stats1['count']:.4g}", "1.049e+06")
         self.assertEqual(f"{stats1['max']:.4g}", "255")
-        self.assertEqual(f"{stats1['mean']:.4g}", "91.15")
+        self.assertEqual(f"{stats1['mean']:.4g}", "91.28")
         self.assertEqual(f"{stats1['min']:.4g}", "0")
-        self.assertEqual(f"{stats1['stddev']:.4g}", "58.76")
-        self.assertEqual(f"{stats1['sum']:.4g}", "9.558e+07")
-        self.assertEqual(f"{stats1['sum_squares']:.4g}", "1.642e+10")
+        self.assertEqual(f"{stats1['stddev']:.4g}", "84.34")
+        self.assertEqual(f"{stats1['sum']:.4g}", "9.571e+07")
+        self.assertEqual(f"{stats1['sum_squares']:.4g}", "1.619e+10")
 
         stats2 = metadata["bands"][2]["stats"]
         self.assertEqual(f"{stats2['count']:.4g}", "1.049e+06")
         self.assertEqual(f"{stats2['max']:.4g}", "255")
         self.assertEqual(f"{stats2['mean']:.4g}", "124")
         self.assertEqual(f"{stats2['min']:.4g}", "0")
-        self.assertEqual(f"{stats2['stddev']:.4g}", "68.08")
-        self.assertEqual(f"{stats2['sum']:.4g}", "1.3e+08")
-        self.assertEqual(f"{stats2['sum_squares']:.4g}", "2.342e+10")
+        self.assertEqual(f"{stats2['stddev']:.4g}", "81.36")
+        self.assertEqual(f"{stats2['sum']:.4g}", "1.301e+08")
+        self.assertEqual(f"{stats2['sum_squares']:.4g}", "2.307e+10")
 
         stats3 = metadata["bands"][3]["stats"]
         self.assertEqual(f"{stats3['count']:.4g}", "1.049e+06")
         self.assertEqual(f"{stats3['max']:.4g}", "255")
-        self.assertEqual(f"{stats3['mean']:.4g}", "189.7")
+        self.assertEqual(f"{stats3['mean']:.4g}", "190")
         self.assertEqual(f"{stats3['min']:.4g}", "0")
-        self.assertEqual(f"{stats3['stddev']:.4g}", "83.36")
-        self.assertEqual(f"{stats3['sum']:.4g}", "1.99e+08")
-        self.assertEqual(f"{stats3['sum_squares']:.4g}", "5.053e+10")
+        self.assertEqual(f"{stats3['stddev']:.4g}", "110.3")
+        self.assertEqual(f"{stats3['sum']:.4g}", "1.992e+08")
+        self.assertEqual(f"{stats3['sum_squares']:.4g}", "5.059e+10")
 
     def test_n37_w123_1arc_v2_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/n37_w123_1arc_v2.tif")
@@ -168,13 +168,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         )
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "9.692e+04")
-        self.assertEqual(f"{stats['max']:.4g}", "377")
-        self.assertEqual(f"{stats['mean']:.4g}", "38.22")
-        self.assertEqual(f"{stats['min']:.4g}", "-7")
-        self.assertEqual(f"{stats['stddev']:.4g}", "54.02")
-        self.assertEqual(f"{stats['sum']:.4g}", "3.704e+06")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "4.539e+08")
+        self.assertEqual(f"{stats['count']:.4g}", "9.755e+04")
+        self.assertEqual(f"{stats['max']:.4g}", "358")
+        self.assertEqual(f"{stats['mean']:.4g}", "38.07")
+        self.assertEqual(f"{stats['min']:.4g}", "-4")
+        self.assertEqual(f"{stats['stddev']:.4g}", "54.59")
+        self.assertEqual(f"{stats['sum']:.4g}", "3.714e+06")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "4.499e+08")
 
     def test_smalltile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -209,11 +209,11 @@ class TestGeotiff2Raquet(unittest.TestCase):
         stats = metadata["bands"][0]["stats"]
         self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
         self.assertEqual(f"{stats['max']:.4g}", "95")
-        self.assertEqual(f"{stats['mean']:.4g}", "75.85")
+        self.assertEqual(f"{stats['mean']:.4g}", "75.82")
         self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "16.47")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
+        self.assertEqual(f"{stats['stddev']:.4g}", "18.3")
+        self.assertEqual(f"{stats['sum']:.4g}", "9.218e+07")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.409e+09")
 
     def test_medtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -250,9 +250,9 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{stats['max']:.4g}", "95")
         self.assertEqual(f"{stats['mean']:.4g}", "75.85")
         self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "17.25") # "16.47")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
+        self.assertEqual(f"{stats['stddev']:.4g}", "18.43")
+        self.assertEqual(f"{stats['sum']:.4g}", "9.226e+07")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.416e+09")
 
     def test_bigtile_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -285,13 +285,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 11)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
+        self.assertEqual(f"{stats['count']:.4g}", "1.218e+06")
         self.assertEqual(f"{stats['max']:.4g}", "95")
-        self.assertEqual(f"{stats['mean']:.4g}", "75.85")
+        self.assertEqual(f"{stats['mean']:.4g}", "75.84")
         self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "18.28") # "16.47")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
+        self.assertEqual(f"{stats['stddev']:.4g}", "18.55")
+        self.assertEqual(f"{stats['sum']:.4g}", "9.236e+07")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.424e+09")
 
     def test_multipart_Annual_NLCD_LndCov_2023_CU_C1V0_tif(self):
         geotiff_filename = os.path.join(
@@ -332,11 +332,11 @@ class TestGeotiff2Raquet(unittest.TestCase):
         stats = metadata["bands"][0]["stats"]
         self.assertEqual(f"{stats['count']:.4g}", "1.216e+06")
         self.assertEqual(f"{stats['max']:.4g}", "95")
-        self.assertEqual(f"{stats['mean']:.4g}", "75.85")
+        self.assertEqual(f"{stats['mean']:.4g}", "75.82")
         self.assertEqual(f"{stats['min']:.4g}", "11")
-        self.assertEqual(f"{stats['stddev']:.4g}", "16.47")
-        self.assertEqual(f"{stats['sum']:.4g}", "9.225e+07")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.415e+09")
+        self.assertEqual(f"{stats['stddev']:.4g}", "18.3")
+        self.assertEqual(f"{stats['sum']:.4g}", "9.218e+07")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "7.409e+09")
 
     def test_geotiff_discreteloss_2023_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/geotiff-discreteloss_2023.tif")
@@ -367,13 +367,13 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(metadata["maxresolution"], 13)
 
         stats = metadata["bands"][0]["stats"]
-        self.assertEqual(f"{stats['count']:.4g}", "2.736e+04")
+        self.assertEqual(f"{stats['count']:.4g}", "2.698e+04")
         self.assertEqual(f"{stats['max']:.4g}", "1")
         self.assertEqual(f"{stats['mean']:.4g}", "1")
         self.assertEqual(f"{stats['min']:.4g}", "1")
         self.assertEqual(f"{stats['stddev']:.4g}", "0")
-        self.assertEqual(f"{stats['sum']:.4g}", "2.736e+04")
-        self.assertEqual(f"{stats['sum_squares']:.4g}", "2.736e+04")
+        self.assertEqual(f"{stats['sum']:.4g}", "2.698e+04")
+        self.assertEqual(f"{stats['sum_squares']:.4g}", "2.698e+04")
 
     def test_colored_tif(self):
         geotiff_filename = os.path.join(PROJDIR, "tests/colored.tif")

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -110,9 +110,6 @@ class RasterStats:
     sum: int | float
     sum_squares: int | float
 
-    # Special value for counting instances of block stats in combine_stats()
-    blocks: int = 1
-
     def scale_by(self, zoom: int) -> "RasterStats":
         """Return approximate equivalent stats for a higher zoom"""
         return RasterStats(
@@ -189,7 +186,6 @@ def combine_stats(
         stddev=prev_stats.stddev * prev_weight + curr_stats.stddev * curr_weight,
         sum=prev_stats.sum + curr_stats.sum,
         sum_squares=prev_stats.sum_squares + curr_stats.sum_squares,
-        blocks=prev_stats.blocks + curr_stats.blocks,
     )
 
     return next_stats

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -636,7 +636,7 @@ def create_metadata(
                 "name": bname,
                 "colorinterp": bcolorinterp,
                 "colortable": bcolortable,
-                "stats": stats.__dict__,
+                "stats": dict(approximated_stats=True, **stats.__dict__),
             }
             for btype, bname, bcolorinterp, bcolortable, stats in zip(
                 rg.bandtypes,

--- a/raquet/geotiff2raquet.py
+++ b/raquet/geotiff2raquet.py
@@ -15,7 +15,6 @@ Required packages:
 """
 
 import argparse
-import copy
 import dataclasses
 import enum
 import gzip
@@ -115,7 +114,7 @@ class RasterStats:
     blocks: int = 1
 
     def scale_by(self, zoom: int) -> "RasterStats":
-        """Return equivalent stats for an approximate higher zoom"""
+        """Return approximate equivalent stats for a higher zoom"""
         return RasterStats(
             self.count * 4**zoom,
             self.min,


### PR DESCRIPTION
Use overview zoom levels when calculating stats to spend less time doing math. Closes https://github.com/CartoDB/raquet/issues/14.

Performance measurements for a sample 150MB input:
- Numpy stats, full res: 1.5sec 
- Numpy stats, this PR: 0.15sec (90% faster)
- Python stats, full res: 44.2sec
- Python stats, this PR: 2.7sec (94% faster)

Accuracy: most values stay close to their full resolution numbers, except for standard deviation which increases in all tests.