### PR TITLE
Fix Warp band-mismatch crash on 4-band rasters with implicit alpha

### DIFF
--- a/raquet/raster2raquet.py
+++ b/raquet/raster2raquet.py
@@ -710,6 +710,67 @@ def find_zoom(resolution: float, zoom_strategy: ZoomStrategy, block_zoom: int) -
     return int(zoom)
 
 
+def _warp_into_new_tile(
+    driver, web_mercator, src_ds, tile, block_zoom, numpy_module, opts, *, extra_bands
+):
+    """Create a fresh tile destination and warp src_ds into it. Returns the tile_ds."""
+    import osgeo.gdal
+
+    tile_ds = create_tile_ds(
+        driver, web_mercator, src_ds, tile, block_zoom, numpy_module,
+        extra_bands=extra_bands,
+    )
+    osgeo.gdal.Warp(
+        destNameOrDestDS=tile_ds, srcDSOrSrcDSTab=src_ds, options=opts,
+    )
+    return tile_ds
+
+
+def warp_source_into_tile_with_alpha_fallback(
+    driver, web_mercator, src_ds, tile, block_zoom, numpy_module, opts, needs_extra_band,
+):
+    """Warp src_ds into a fresh tile destination, retrying once with an extra
+    alpha band if Warp complained that the destination is missing one.
+
+    GDAL Warp implicitly adds an alpha mask band when the source's photometric
+    metadata is ambiguous (e.g. SamplesPerPixel doesn't match the declared
+    color channels). The destination must have one extra band to receive that
+    mask, otherwise Warp raises:
+        RuntimeError: Destination dataset has N bands, but at least N+1 are needed
+
+    The caller should keep `needs_extra_band` sticky across tiles in the same
+    raster: once one tile has needed the +1 layout, every subsequent tile of
+    the same source will need it too, so we avoid a 2x Warp on every tile.
+
+    Returns (tile_ds, needs_extra_band_now).
+    """
+    import osgeo.gdal
+
+    extras = 1 if needs_extra_band else 0
+    try:
+        tile_ds = _warp_into_new_tile(
+            driver, web_mercator, src_ds, tile, block_zoom, numpy_module, opts,
+            extra_bands=extras,
+        )
+        return tile_ds, needs_extra_band
+    except RuntimeError:
+        if needs_extra_band:
+            # We're already on the +1 path; this is a different problem.
+            raise
+        # Discard the partial /vsimem/ dataset before retrying with one extra band.
+        osgeo.gdal.Unlink(f"/vsimem/tile-{tile.z}-{tile.x}-{tile.y}.tif")
+        tile_ds = _warp_into_new_tile(
+            driver, web_mercator, src_ds, tile, block_zoom, numpy_module, opts,
+            extra_bands=1,
+        )
+        logging.info(
+            "Warp required an extra alpha band on tile %s; using +1 layout for "
+            "remaining tiles of this raster.",
+            tile,
+        )
+        return tile_ds, True
+
+
 def create_tile_ds(
     driver: "osgeo.gdal.Driver",  # noqa: F821 (osgeo types safely imported in read_raster)
     web_mercator: "osgeo.osr.SpatialReference",  # noqa: F821 (osgeo types safely imported in read_raster)
@@ -717,14 +778,21 @@ def create_tile_ds(
     tile: mercantile.Tile,
     block_zoom: int,
     numpy_module: "module | None" = None,  # noqa: F821
+    extra_bands: int = 0,
 ) -> "osgeo.gdal.Dataset":  # noqa: F821 (osgeo types safely imported in read_raster)
-    # Initialize warped tile dataset and its bands
+    # Initialize warped tile dataset and its bands.
+    #
+    # extra_bands > 0 reserves space for an alpha mask that GDAL Warp may add
+    # when the source's photometric/extrasamples metadata is ambiguous (e.g.
+    # 4-band Byte rasters where SamplesPerPixel doesn't match the declared
+    # color channels). Without that space Warp raises
+    # `RuntimeError: Destination dataset has N bands, but at least N+1 are needed`.
     tile_size = 2**block_zoom
     tile_ds = driver.Create(
         f"/vsimem/tile-{tile.z}-{tile.x}-{tile.y}.tif",
         tile_size,
         tile_size,
-        ds.RasterCount,
+        ds.RasterCount + extra_bands,
         ds.GetRasterBand(1).DataType,
     )
     tile_ds.SetProjection(web_mercator.ExportToWkt())
@@ -763,16 +831,22 @@ def read_raster_data_stats(
     band_layout: BandLayout = BandLayout.SEQUENTIAL,
     compression: CompressionCodec = CompressionCodec.GZIP,
     compression_quality: int = 85,
+    band_count: int | None = None,
 ) -> tuple[list[bytes], list[RasterStats | None]]:
     """Read data and stats from warped bands
 
     For SEQUENTIAL layout: returns list of compressed band data (one per band)
     For INTERLEAVED layout: returns list with single element (all bands interleaved)
+
+    If band_count is provided, only the first band_count bands are read. This
+    is used to skip an alpha mask band that Warp may have added on top of the
+    raster's data bands (see create_tile_ds extra_bands).
     """
     block_data, block_stats = [], []
     raw_bands = []  # Store raw band data for interleaving
 
-    for band_num in range(1, 1 + ds.RasterCount):
+    n_bands = band_count if band_count is not None else ds.RasterCount
+    for band_num in range(1, 1 + n_bands):
         band = ds.GetRasterBand(band_num)
         data = band.ReadRaster(0, 0, band.XSize, band.YSize)
 
@@ -1078,6 +1152,10 @@ def read_raster(
             )
         ]
 
+        # Sticky: once any tile of this raster has needed an extra alpha band,
+        # every subsequent tile from the same source will need it too.
+        needs_extra_band = False
+
         while frames:
             frame = frames.pop()
             tile_ds: osgeo.gdal.Dataset | None = None
@@ -1091,18 +1169,23 @@ def read_raster(
             if frame.tile.z == raster_geometry.zoom:
                 # Read original source pixels at the highest requested zoom
                 logging.info("Warp %s from original dataset", frame.tile)
-                tile_ds = create_tile_ds(*create_args)
-                osgeo.gdal.Warp(
-                    destNameOrDestDS=tile_ds, srcDSOrSrcDSTab=src_ds, options=opts_source
+                tile_ds, needs_extra_band = warp_source_into_tile_with_alpha_fallback(
+                    gtiff_driver, web_mercator, src_ds, frame.tile, block_zoom, numpy_mod,
+                    opts_source, needs_extra_band,
                 )
                 d, s = read_raster_data_stats(
                     tile_ds, gdaltype_bandtypes, do_stats,
-                    band_layout, compression, compression_quality
+                    band_layout, compression, compression_quality,
+                    band_count=src_ds.RasterCount,
                 )
                 pipe.send((frame.tile, d, s))
             elif not frame.inputs:
-                # Build overview tile - either from COG overviews or from child tiles
-                tile_ds = create_tile_ds(*create_args)
+                # Build overview tile - either from COG overviews or from child tiles.
+                # extra_bands matches the native-zoom layout so the pyramid stays
+                # consistent and Warp into this dst doesn't fail for the same reason.
+                tile_ds = create_tile_ds(
+                    *create_args, extra_bands=1 if needs_extra_band else 0
+                )
 
                 # Try to use COG overview if available
                 cog_overview_used = False
@@ -1172,7 +1255,8 @@ def read_raster(
 
                 d, s1 = read_raster_data_stats(
                     tile_ds, gdaltype_bandtypes, do_stats,
-                    band_layout, compression, compression_quality
+                    band_layout, compression, compression_quality,
+                    band_count=src_ds.RasterCount,
                 )
                 s2 = [s.scale_by(stats_zoom_diff) if s else None for s in s1]
                 pipe.send((frame.tile, d, s2))
@@ -1270,18 +1354,22 @@ def _read_raster_worker(
         # Stats zoom for this worker (native zoom, no overviews)
         stats_zoom = max(tiles[0].z + STATS_ZOOM_OFFSET, tiles[0].z)
 
+        # Sticky: once any tile of this raster has needed an extra alpha band,
+        # every subsequent tile from the same source will need it too.
+        needs_extra_band = False
+
         for tile in tiles:
-            create_args = gtiff_driver, web_mercator, src_ds, tile, block_zoom, numpy_mod
             # When tile_stats is enabled, compute stats for every tile
             do_stats = tile_stats or tile.z == stats_zoom
 
-            tile_ds = create_tile_ds(*create_args)
-            osgeo.gdal.Warp(
-                destNameOrDestDS=tile_ds, srcDSOrSrcDSTab=src_ds, options=opts_source
+            tile_ds, needs_extra_band = warp_source_into_tile_with_alpha_fallback(
+                gtiff_driver, web_mercator, src_ds, tile, block_zoom, numpy_mod,
+                opts_source, needs_extra_band,
             )
             d, s = read_raster_data_stats(
                 tile_ds, gdaltype_bandtypes, do_stats,
-                band_layout, compression, compression_quality
+                band_layout, compression, compression_quality,
+                band_count=src_ds.RasterCount,
             )
             queue.put((tile, d, s))
             tile_ds = None

--- a/tests/test_geotiff2raquet.py
+++ b/tests/test_geotiff2raquet.py
@@ -1,6 +1,7 @@
 import glob
 import itertools
 import math
+import multiprocessing
 import os
 import tempfile
 import unittest
@@ -9,6 +10,35 @@ import pyarrow.parquet
 from raquet import geotiff2raquet
 
 PROJDIR = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _build_4band_byte_alpha_mismatch_geotiff(path: str) -> None:
+    """Build a 4-band Byte GeoTIFF with photometric / SamplesPerPixel mismatch.
+
+    Run in a `spawn`'d subprocess only — importing osgeo in the test parent
+    process clashes with pyarrow's filesystem registry (apache/arrow#44696)
+    and would mask the actual failure shape with a different exception.
+    """
+    from osgeo import gdal, osr
+
+    drv = gdal.GetDriverByName("GTiff")
+    ds = drv.Create(path, 1024, 1024, 4, gdal.GDT_Byte, options=["COMPRESS=DEFLATE"])
+    ds.SetGeoTransform([-10.0, 0.02, 0.0, 50.0, 0.0, -0.02])
+    sref = osr.SpatialReference()
+    sref.ImportFromEPSG(4326)
+    ds.SetSpatialRef(sref)
+    color_interps = [
+        gdal.GCI_GrayIndex,
+        gdal.GCI_Undefined,
+        gdal.GCI_Undefined,
+        gdal.GCI_Undefined,
+    ]
+    for i, ci in enumerate(color_interps, start=1):
+        b = ds.GetRasterBand(i)
+        b.SetColorInterpretation(ci)
+        b.SetNoDataValue(255)
+        b.Fill(42 + i)
+    ds.FlushCache()
 
 
 class TestGeotiff2Raquet(unittest.TestCase):
@@ -438,3 +468,53 @@ class TestGeotiff2Raquet(unittest.TestCase):
         self.assertEqual(f"{metadata['bounds'][1]:.3g}", "-85.1")
         self.assertEqual(f"{metadata['bounds'][2]:.3g}", "180")
         self.assertEqual(f"{metadata['bounds'][3]:.3g}", "85.1")
+
+    def test_4band_byte_alpha_mismatch(self):
+        """Regression: 4-band Byte GeoTIFF where photometric metadata makes
+        gdal.Warp implicitly add an alpha mask band. Used to crash with
+        `RuntimeError: Destination dataset has 4 bands, but at least 5 are
+        needed`. Should now convert cleanly with the original 4 data bands
+        in the parquet output (the alpha mask is discarded).
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            tif = os.path.join(tempdir, "synth-4band-byte.tif")
+
+            # Build the input in a spawn'd subprocess so osgeo never loads in
+            # this test process — importing both osgeo and pyarrow in the same
+            # process collides on the 'file' filesystem registration.
+            ctx = multiprocessing.get_context("spawn")
+            proc = ctx.Process(
+                target=_build_4band_byte_alpha_mismatch_geotiff, args=(tif,)
+            )
+            proc.start()
+            proc.join(timeout=60)
+            self.assertEqual(proc.exitcode, 0, "GeoTIFF builder subprocess failed")
+
+            raquet_filename = os.path.join(tempdir, "out.parquet")
+            geotiff2raquet.main(
+                tif,
+                raquet_filename,
+                geotiff2raquet.ZoomStrategy.AUTO,
+                geotiff2raquet.ResamplingAlgorithm.NearestNeighbour,
+                9,
+            )
+            table = pyarrow.parquet.read_table(raquet_filename)
+
+        # All four original data bands made it into the output; the implicit
+        # alpha mask Warp may have added is intentionally not persisted.
+        self.assertEqual(
+            table.column_names,
+            ["block", "metadata", "band_1", "band_2", "band_3", "band_4"],
+        )
+        metadata = geotiff2raquet.read_metadata(table)
+        self.assertEqual(len(metadata["bands"]), 4)
+        # Critical: at least one data tile was actually written. Without the
+        # fix, the worker process crashes mid-warp and the parent emits a
+        # parquet with the metadata row but zero data rows — visible only
+        # by checking that the table is more than the metadata header.
+        self.assertGreater(
+            len(table),
+            1,
+            f"Expected at least one data tile in addition to the metadata row; "
+            f"got {len(table)}. Worker likely crashed mid-warp.",
+        )


### PR DESCRIPTION
## Summary

When a source raster has photometric metadata that doesn't add up cleanly (e.g. `SamplesPerPixel != color channels + ExtraSamples`, or RGBA inputs with ambiguous alpha tagging), GDAL Warp implicitly adds an alpha mask band to the destination. `create_tile_ds` was allocating exactly `src.RasterCount` bands, so Warp raised:

```
RuntimeError: Destination dataset has N bands, but at least N+1 are needed
```

The worker process died on that exception. Depending on raquet's version, the parent process either propagated `AttributeError: 'NoneType' object has no attribute '__dict__'` (when `create_metadata` tried to read missing stats) or silently produced a parquet with the metadata row but zero data tiles — both end with no usable output.

This was hit in production by a customer (CARTO/cloud-native) importing a 4-band Byte GeoTIFF whose `Photometric` was `Gray` (1 color channel) but `SamplesPerPixel` was 4, with the remaining 3 bands tagged `ExtraSamples=Unspecified`.

## Approach

Strategy: **retry once with an extra band, then make the choice sticky for the rest of the raster.** Detection by failure rather than upfront introspection — GDAL's alpha heuristics drift across versions, so destination band-count is the only signal that's stable.

- `create_tile_ds` accepts a new `extra_bands: int = 0` so callers can reserve one extra band for the alpha mask Warp may add.
- `read_raster_data_stats` accepts a new `band_count: int | None = None` so the alpha band is excluded from the parquet output (only the original data bands are persisted).
- The native-zoom Warp now goes through `warp_source_into_tile_with_alpha_fallback`, which catches `RuntimeError` and retries once with `extra_bands=1`. The result returns a `needs_extra_band` flag the caller keeps sticky across tiles in the same raster — so the retry happens **at most once per raster**, never per-tile.
- Same logic applied to the parallel `_read_raster_worker`.

## Cost model

- **Healthy rasters**: zero overhead. The fast path is unchanged: `create_tile_ds` allocates `RasterCount` bands, Warp succeeds, done.
- **Affected rasters**: exactly one extra Warp call across the whole raster (the failed first attempt on tile #1). Subsequent tiles know to allocate `RasterCount + 1` from the start.

## Validation

- `tests/test_geotiff2raquet.py::TestGeotiff2Raquet::test_4band_byte_alpha_mismatch` — new regression test that builds a synthetic 4-band Byte GeoTIFF matching the customer shape (`Photometric=Gray + 3x Undefined`, `noDataValue=255`) and asserts the parquet output contains at least one data tile. Verified that this test **fails** on `master` without the fix (parquet has only the metadata row, `len(table) == 1`) and **passes** with the fix (`len(table) == 19`, full pyramid).
- Synthetic GeoTIFF is built in a `spawn`'d subprocess so osgeo never loads in the test parent — pyarrow and osgeo collide on the `'file'` filesystem registration when loaded in the same interpreter (apache/arrow#44696).
- Healthy 3-band RGB GeoTIFF: unchanged behaviour, single Warp call per tile (verified out-of-tree).
- Full `tests/test_geotiff2raquet.py`: 17/17 pass with the fix.
- Full suite (excluding `test_earthengine.py` and `test_imageserver.py` which need external creds): 46/47 pass. The one failure (`test_cli.py::TestVersion::test_version`) is pre-existing and reproduces on clean `master` — it's an environment quirk where `importlib.metadata` can't find the `raquet-io` distribution when running via `PYTHONPATH` without `pip install`.

## Notes

- The "broad `RuntimeError` catch" in `warp_source_into_tile_with_alpha_fallback` is intentional: any first-tile failure triggers a single retry with the wider destination, and if that also fails the second exception is propagated as-is. Worst case for an unrelated RuntimeError is one extra Warp call before the real error surfaces.
- An alpha mask written into the extra band by Warp is silently discarded by `read_raster_data_stats` (it only iterates `band_count` bands). If a future user wants alpha-aware handling, that would be an opt-in extension on top of this patch — not affected by this change.
- Separate concern spotted while validating: master's `convert_to_raquet_files` swallows worker-death and produces an empty-but-valid parquet (the symptom that the new regression test catches via `len(table) > 1`). Even with this PR's fix in place, the parent could benefit from propagating worker exceptions instead of producing zero-data outputs. Out of scope here, worth a follow-up.